### PR TITLE
fix(ndex-client): resolve Buffer/BlobPart type incompatibility in newer TypeScript

### DIFF
--- a/packages/ndex-client/src/services/HTTPService.ts
+++ b/packages/ndex-client/src/services/HTTPService.ts
@@ -251,7 +251,9 @@ export class HTTPService {
       formData.append('file', blob, 'file.cx2');
     } else if (typeof (globalThis as any).Buffer !== 'undefined' && (globalThis as any).Buffer.isBuffer(file)) {
       // Node Buffer → convert to Blob so it works with web FormData (Node 18+)
-      const blob = new Blob([file as Buffer], { type: contentType || 'application/octet-stream' });
+      const buf = file as Buffer;
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+      const blob = new Blob([ab], { type: contentType || 'application/octet-stream' });
       formData.append('file', blob, 'file.cx2');
     } else {
       // Fallback: coerce to string and wrap in Blob

--- a/packages/ndex-client/src/services/NetworkServiceV3.ts
+++ b/packages/ndex-client/src/services/NetworkServiceV3.ts
@@ -280,7 +280,10 @@ export class NetworkServiceV3 {
       const blob = new Blob([cx2], { type: 'application/json' });
       formData.append('CXNetworkStream', blob, 'network.cx2');
     } else if (typeof (globalThis as any).Buffer !== 'undefined' && (globalThis as any).Buffer.isBuffer(cx2)) {
-      const blob = new Blob([cx2 as Buffer], { type: 'application/json' });
+      const buf = cx2 as Buffer;
+      // Copy to a clean ArrayBuffer to avoid TS Buffer/BlobPart incompatibility
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+      const blob = new Blob([ab], { type: 'application/json' });
       formData.append('CXNetworkStream', blob, 'network.cx2');
     } else {
       const blob = new Blob([String(cx2)], { type: 'application/json' });


### PR DESCRIPTION
## Summary

In recent TypeScript versions (5.x) with updated Node type definitions, `Buffer` is no longer directly assignable to `BlobPart` because `Buffer.buffer` is typed as `ArrayBufferLike` (which includes `SharedArrayBuffer`), while `BlobPart` requires a strict `ArrayBuffer`. This causes the DTS build to fail with:

```
error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'BlobPart'.
```

## Changes

Fix by copying the Buffer's underlying data to a clean `ArrayBuffer` via `buffer.slice()` with an explicit `as ArrayBuffer` cast before passing to the `Blob` constructor.

- **`packages/ndex-client/src/services/HTTPService.ts`**: `uploadFile()` Buffer branch (line ~254)
- **`packages/ndex-client/src/services/NetworkServiceV3.ts`**: `uploadCX2Network()` Buffer branch (line ~283)

## Verification

- ndex-client builds successfully (CJS + ESM + IIFE + DTS — all four outputs)
- All 180 unit tests pass
- ndex3 (downstream consumer) production build succeeds with this fix

---

Co-Authored-By: Oz <oz-agent@warp.dev>
[Warp conversation](https://app.warp.dev/conversation/fb2816ce-3033-424b-9b9b-e43641e7900e)